### PR TITLE
Support qBittorrent's new QBT_SID session cookie format

### DIFF
--- a/QbtManager/qbtService.cs
+++ b/QbtManager/qbtService.cs
@@ -95,7 +95,10 @@ namespace QbtManager
 
                 var response = client.Execute(request);
 
-                var sessionCookie = response.Cookies.SingleOrDefault(x => x.Name == "SID");
+                // qBittorrent renamed the WebUI session cookie from "SID" to "QBT_SID_<port>"
+                // in newer versions. Accept both so login works across versions.
+                var sessionCookie = response.Cookies.SingleOrDefault(x => x.Name == "SID"
+                    || x.Name.StartsWith("QBT_SID", StringComparison.OrdinalIgnoreCase));
                 if (sessionCookie != null)
                 {
                     client.CookieContainer.Add(new Cookie(sessionCookie.Name, sessionCookie.Value, sessionCookie.Path, sessionCookie.Domain));


### PR DESCRIPTION
## Summary
Updated the session cookie detection logic to support both the legacy "SID" cookie name and the newer "QBT_SID_<port>" format used by recent versions of qBittorrent's WebUI.

## Key Changes
- Modified cookie lookup in `SignIn()` method to accept both "SID" and cookies starting with "QBT_SID" (case-insensitive)
- Added explanatory comment documenting the qBittorrent version change
- Maintains backward compatibility with older qBittorrent versions that still use the "SID" cookie

## Implementation Details
The session cookie detection now uses a compound condition that checks for either:
1. Exact match on "SID" (legacy format)
2. Cookie name starting with "QBT_SID" using case-insensitive comparison

This ensures the authentication flow works seamlessly across qBittorrent versions without requiring users to upgrade or reconfigure.

https://claude.ai/code/session_01EgL7a13MvXA8ZwZ95seSMs