### PR TITLE
Fix setShareLimits 400 by sending required shareLimitAction param

### DIFF
--- a/QbtManager/qbtService.cs
+++ b/QbtManager/qbtService.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.Text.Json.Serialization;
 using System.Text;
 using System.Security.Cryptography;
+using System.Globalization;
 
 namespace QbtManager
 {
@@ -257,9 +258,12 @@ namespace QbtManager
             var parms = new Dictionary<string, string>();
 
             parms["hashes"] = string.Join("|", taskIds);
-            parms["ratioLimit"] = maxRatio.ToString();
-            parms["seedingTimeLimit"] = maxSeedingTime.ToString();
+            parms["ratioLimit"] = maxRatio.ToString(CultureInfo.InvariantCulture);
+            parms["seedingTimeLimit"] = maxSeedingTime.ToString(CultureInfo.InvariantCulture);
             parms["inactiveSeedingTimeLimit"] = "-1"; // new parameter https://github.com/qbittorrent/qBittorrent/pull/19294
+            // qBittorrent 5.1+ requires shareLimitAction. "Default" = use the global
+            // action when a limit is reached, preserving the prior behaviour.
+            parms["shareLimitAction"] = "Default";
             Utils.Log("Setting Limits to ratio " + parms["ratioLimit"] + " seeding time " + parms["seedingTimeLimit"] + " for " + taskIds.Length.ToString() + " tasks ");
             return ExecuteCommand("/torrents/setShareLimits", parms);
         }
@@ -281,7 +285,7 @@ namespace QbtManager
 
             if (queryResult.StatusCode != HttpStatusCode.OK)
             {
-                Utils.Log($"ERROR: Request failed: {requestMethod}: {queryResult.ResponseStatus}");
+                Utils.Log($"ERROR: Request failed: {requestMethod}: {(int)queryResult.StatusCode} {queryResult.StatusCode} - {queryResult.Content}");
             }
 
             return queryResult.StatusCode == HttpStatusCode.OK;
@@ -304,7 +308,7 @@ namespace QbtManager
 
             if( queryResult.StatusCode != HttpStatusCode.OK )
             {
-                Utils.Log($"ERROR: Command failed: {requestMethod}: {queryResult.ResponseStatus}");
+                Utils.Log($"ERROR: Command failed: {requestMethod}: {(int)queryResult.StatusCode} {queryResult.StatusCode} - {queryResult.Content}");
             }
 
             return queryResult.StatusCode == HttpStatusCode.OK;


### PR DESCRIPTION
## Problem

After signing in successfully, every run failed to apply ratio/seeding limits:

```
[INF] Setting Limits to ratio -1 seeding time -1 for 128 tasks
[INF] ERROR: Command failed: /torrents/setShareLimits: Completed
[INF] Failed to set max ratio and time limit.
```

The log only showed RestSharp's transport status (`Completed`), not the HTTP code. A direct curl revealed the real response:

```
HTTP/1.1 400 Bad Request
Missing required parameters: shareLimitAction
```

qBittorrent 5.1 made **`shareLimitAction` a required parameter** of `/torrents/setShareLimits`. `SetMaxLimits()` never sent it, so every call 400'd and limits were silently never applied.

## Changes (`QbtManager/qbtService.cs`)

- **Fix:** send `shareLimitAction="Default"` from `SetMaxLimits()`. `Default` tells qBittorrent to use the global action when a share limit is reached, preserving the previous behaviour (the tool only ever managed the ratio/time values, not the action).
- **Diagnostics:** `ExecuteCommand()` / `ExecuteRequest()` now log the HTTP status code **and response body** on failure instead of RestSharp's transport status, so an API change like this is immediately visible rather than a guessing game.
- **Locale hardening:** format `ratioLimit` / `seedingTimeLimit` with `InvariantCulture` so a comma-decimal system locale can't send `1,2` and trigger an unrelated 400.

## Verification

Adding `&shareLimitAction=Default` to the failing curl flips it from `400` to `200`:

```bash
curl -s -i -b cj.txt -X POST \
  --data "hashes=$HASH&ratioLimit=2&seedingTimeLimit=-1&inactiveSeedingTimeLimit=-1&shareLimitAction=Default" \
  http://localhost:8080/api/v2/torrents/setShareLimits
```

After rebuilding `qbtmanager2023`, the `Failed to set max ratio and time limit.` errors are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EgL7a13MvXA8ZwZ95seSMs)_